### PR TITLE
fix(quill): downgrade quill v2.0.3 to v2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "ngx-toastr": "~16.1.0",
         "overlayscrollbars": "~1.7.3",
         "pdfjs-dist": "5.4.149",
-        "quill": "2.0.3",
+        "quill": "2.0.2",
         "quill-mention": "^6.0.2",
         "rxjs": "~7.8.0",
         "shpjs": "^6.2.0",
@@ -33530,9 +33530,9 @@
       "license": "MIT"
     },
     "node_modules/quill": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
-      "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.2.tgz",
+      "integrity": "sha512-QfazNrhMakEdRG57IoYFwffUIr04LWJxbS/ZkidRFXYCQt63c1gK6Z7IHUXMx/Vh25WgPBU42oBaNzQ0K1R/xw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "eventemitter3": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ngx-toastr": "~16.1.0",
     "overlayscrollbars": "~1.7.3",
     "pdfjs-dist": "5.4.149",
-    "quill": "2.0.3",
+    "quill": "2.0.2",
     "quill-mention": "^6.0.2",
     "rxjs": "~7.8.0",
     "shpjs": "^6.2.0",


### PR DESCRIPTION
See https://github.com/slab/quill/issues/4535. Version 2.0.3 contains a breaking change that converts all spaces in the rich text editor to a non-breaking space HTML entity.